### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,926 @@
-# LOM - Localization
+# Localization
 
-Localization system used in project Library of Meialia
+A lightweight Unity localization package for runtime translation, localized UI text, object-based localization contexts, language-file assets, and editor-side localization management.
 
-This system is capable of running in other Unity Projects, but it requires the [Unity Utilities](https://github.com/Minerva-Studio/Unity-Utilities) library.
+## Features
 
-Discord: [Join](https://discord.com/invite/pPbHMcSB7W)
+| Feature | Description |
+| --- | --- |
+| Key-value localization | Fetch text by key, with modular files, merged sources, and hierarchical key paths such as `game.ui.start`. |
+| Runtime translation API | `L10n` handles initialization, language loading, translation, missing keys, runtime overrides, and default-region reads. |
+| Structured parameters | `L10nParams` separates key option segments from dynamic variables and replaces ambiguous legacy `params string[]` usage. |
+| Dynamic values and contexts | `L10nContext` / `ILocalizableContext` bind objects to key roots and provide runtime values for placeholders. |
+| Expression parsing | Localization text supports `{value}`, `{a + b}`, `{value:0.0}`, and parameterized dynamic values. |
+| Inline references | `$Key.Path$` / `$@Key.Path$` embed other localized strings and can participate in tooltip import behavior. |
+| Color tags | `§Rtext§`, `§#ff8800text§`, and `§<Keyword>text§` convert to TMP/UGUI-compatible `<color>` tags. |
+| UI components | Built-in localizers support TextMeshPro and legacy `UnityEngine.UI.Text`. |
+| Editor tools | `.yml` / `.lang` import, key management, CSV import/export, sorting, and missing-key workflows are available in editor code. |
+| Extension points | Projects can provide custom formatters, contexts, color resolvers, and missing-key behavior. |
+
+## Requirements
+
+- Unity `2021.3` or newer
+- A Unity project that can load assets from `Assets/Resources`
+- The Unity utility dependencies required by this package
+- TextMeshPro, if using the TextMeshPro localizer component
+
+Package manifest:
+
+```json
+{
+  "name": "com.minervagamestudio.localization",
+  "version": "0.4.0",
+  "displayName": "Localization",
+  "unity": "2021.3"
+}
+```
+
+## Installation
+
+Add the package to `Packages/manifest.json`:
+
+```json
+{
+  "dependencies": {
+    "com.minervagamestudio.localization": "https://github.com/minerva-studio/localization.git"
+  }
+}
+```
+
+You can also install it from Unity:
+
+```text
+Window > Package Manager > + > Add package from git URL...
+```
+
+Then paste:
+
+```text
+https://github.com/minerva-studio/localization.git
+```
+
+## Quick Start
+
+### 1. Create a Localization Manager
+
+Create a `L10nDataManager` asset from Unity's asset menu:
+
+```text
+Create > Localization > Localization Manager
+```
+
+The manager owns:
+
+- `defaultRegion`
+- `regions`
+- `files`
+- `sources`
+- `missingKeySolution`
+- `referenceImportOption`
+- `tooltipImportOption`
+- `useUnderlineResolver`
+- `wordSpace`
+- `listDelimiter`
+
+### 2. Assign the Manager to Localization Settings
+
+The package loads project settings from:
+
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
+```
+
+Open the `LocalizationSetting` asset and assign the `L10nDataManager` to its `manager` field.
+
+At runtime, `LocalizationSettings` loads this asset from `Resources` and initializes `L10n`.
+
+### 3. Create Language Files
+
+A language file is a `LanguageFile` asset or an imported `.lang` / `.yml` file.
+
+Suggested layout:
+
+```text
+Assets/
+  Resources/
+    Localization/
+      LocalizationSetting.asset
+      Base/
+        Lang_UI.yml
+      EN_US/
+        Lang_UI_EN_US.lang
+      ZH_CN/
+        Lang_UI_ZH_CN.lang
+```
+
+Use the exact region strings configured in `L10nDataManager.regions`.
+
+Example entries:
+
+```yml
+Game.UI.MainMenu.Start.name: Start
+Game.UI.MainMenu.Quit.name: Quit
+Game.UI.MainMenu.Quit.msg: Are you sure you want to quit?
+```
+
+### 4. Load a Region
+
+The system auto-initializes from `LocalizationSettings`, but a game can explicitly load a region:
+
+```csharp
+using Minerva.Localizations;
+
+L10n.Init();
+L10n.Load("EN_US");
+```
+
+To initialize from a specific manager:
+
+```csharp
+L10n.InitAndLoad(manager, "EN_US");
+```
+
+When a language is loaded, `L10n.OnLocalizationLoaded` is invoked. Built-in text localizers listen to this event and refresh themselves.
+
+## Core Concepts
+
+### L10nDataManager
+
+`L10nDataManager` is the editor and runtime hub for localization data. It is a `ScriptableObject` created from:
+
+```text
+Create > Localization > Localization Manager
+```
+
+It manages supported regions, language files, source files, key collection rebuilding, sorting, import/export behavior, reference import options, tooltip import options, and missing-key behavior.
+
+### LocalizationSettings
+
+`LocalizationSettings` is the project-level settings asset loaded from:
+
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
+```
+
+It stores the active `L10nDataManager` reference used to initialize the localization system at runtime.
+
+### L10n
+
+`L10n` is the main runtime facade. It handles:
+
+- `Init`
+- `Load`
+- `Reload`
+- `Tr`
+- `TrKey`
+- `TrRaw`
+- `TryTr`
+- `TrDefault`
+- `Contains`
+- `Exist`
+- `Write`
+- `OptionOf`
+
+After a region is loaded, `L10n.OnLocalizationLoaded` is raised so UI localizers and other listeners can refresh displayed text.
+
+### LanguageFile
+
+`LanguageFile` is the concrete language content asset. It contains a `region`, a `tag`, localization `entries`, and optional child files.
+
+Master files merge their own entries and child-file entries. If duplicate keys exist, the later imported entry overrides the earlier one and a warning is logged.
+
+## Runtime API
+
+### Basic Translation
+
+```csharp
+string text = L10n.Tr("Game.UI.MainMenu.Start.name", L10nParams.Empty);
+```
+
+Legacy calls without `L10nParams` are still supported:
+
+```csharp
+string text = L10n.Tr("Game.UI.MainMenu.Start.name");
+```
+
+### Translation with Options
+
+`L10nParams` option segments are appended to the base key.
+
+```csharp
+string name = L10n.Tr("Game.Item.HealthPotion", L10nParams.Create("name"));
+string desc = L10n.Tr("Game.Item.HealthPotion", L10nParams.Create("desc"));
+```
+
+These calls resolve:
+
+```text
+Game.Item.HealthPotion.name
+Game.Item.HealthPotion.desc
+```
+
+Multiple options are appended in order:
+
+```csharp
+string desc = L10n.Tr(
+    "Game.Effect.Buff",
+    L10nParams.Create("Fire", "desc")
+);
+```
+
+This resolves:
+
+```text
+Game.Effect.Buff.Fire.desc
+```
+
+### Translation with Variables
+
+```csharp
+string text = L10n.Tr(
+    "Game.UI.Timer.info",
+    L10nParams.Create().With("seconds", 12.5f)
+);
+```
+
+Language entry:
+
+```yml
+Game.UI.Timer.info: "Time: {seconds:0.0}s"
+```
+
+### Object-Based Translation
+
+If a type has a registered localization context, it can be translated directly:
+
+```csharp
+string displayName = L10n.Tr(itemData, L10nParams.Create("name"));
+string description = L10n.Tr(itemData, L10nParams.Create("desc"));
+```
+
+Internally, this resolves the object to `L10nContext.Of(object)`, builds the localization key, reads raw content, and evaluates localization escape patterns.
+
+### Explicit Context Translation
+
+Use `TrKey` when the key is explicit but dynamic values should come from a context:
+
+```csharp
+var context = L10nContext.Of(itemData);
+string text = L10n.TrKey("Game.UI.Inventory.Selected.info", context, L10nParams.Empty);
+```
+
+### Raw Content Translation
+
+Use `TrRaw` when the raw string is already available but still needs variables, references, or color tags resolved:
+
+```csharp
+var context = L10nContext.Of(itemData);
+
+string text = L10n.TrRaw(
+    "Price: {price}",
+    context,
+    L10nParams.Empty
+);
+```
+
+### Default-Region Translation
+
+Use `TrDefault` to read from the default localization region:
+
+```csharp
+string fallback = L10n.TrDefault("Game.UI.MainMenu.Start.name", L10nParams.Empty);
+```
+
+## L10nParams
+
+`L10nParams` separates key option segments from dynamic variables.
+
+### Empty Parameters
+
+```csharp
+var parameters = L10nParams.Empty;
+var another = L10nParams.Create();
+```
+
+### Option Segments
+
+```csharp
+var nameOption = L10nParams.Create("name");
+var nestedOption = L10nParams.Create("Fire", "desc");
+```
+
+### Variables
+
+```csharp
+var parameters = L10nParams
+    .Create("desc")
+    .With("level", 2)
+    .With("damage", 12.5f);
+```
+
+Multiple variables can be added at once:
+
+```csharp
+var parameters = L10nParams
+    .Create("desc")
+    .With(
+        ("level", 2),
+        ("damage", 12.5f),
+        ("cooldown", 3.0f)
+    );
+```
+
+### Updating Options
+
+```csharp
+parameters = parameters.WithOptions("name");
+parameters = parameters.AppendOptions("tooltip");
+parameters = parameters.PrependOptions("Common");
+```
+
+### Legacy String Parameters
+
+Legacy string parameters are converted with `L10nParams.FromStrings(...)`.
+
+```csharp
+L10n.Tr("Game.Item.HealthPotion", "name", "level=2");
+```
+
+Conversion rules:
+
+- strings without `=` become options
+- strings with `=` become variables
+
+For example, `["Daily", "level=2", "desc"]` becomes:
+
+- Options: `["Daily", "desc"]`
+- Variables: `{ "level": "2" }`
+
+Prefer explicit `L10nParams` in new code:
+
+```csharp
+L10n.Tr(
+    "Game.Item.HealthPotion",
+    L10nParams.Create("name").With("level", 2)
+);
+```
+
+## Localization Contexts
+
+Localization contexts define how objects map to localization keys and dynamic values.
+
+### ILocalizableContext
+
+A custom context can implement `ILocalizableContext`:
+
+```csharp
+using Minerva.Localizations;
+
+public sealed class ItemL10nContext : ILocalizableContext
+{
+    private readonly ItemData item;
+
+    public ItemL10nContext(ItemData item)
+    {
+        this.item = item;
+    }
+
+    public string BaseKeyString => $"Game.Item.{item.ID}";
+
+    public object GetEscapeValue(string escapeKey, L10nParams parameters)
+    {
+        return escapeKey switch
+        {
+            "level" => item.Level,
+            "rarity" => item.Rarity,
+            _ => escapeKey
+        };
+    }
+}
+```
+
+### L10nContext
+
+For reusable object mappings, derive from `L10nContext` and register it:
+
+```csharp
+using Minerva.Localizations;
+
+public sealed class ItemL10nContext : L10nContext
+{
+    private ItemData item;
+
+    protected override void Parse(object value)
+    {
+        item = (ItemData)value;
+        BaseKeyString = $"Game.Item.{item.ID}";
+        BaseValue = item;
+    }
+}
+```
+
+Register the context during initialization:
+
+```csharp
+L10nContext.Register<ItemL10nContext, ItemData>();
+```
+
+Use `allowInheritance: true` when the same context should apply to child classes:
+
+```csharp
+L10nContext.Register<ItemL10nContext, ItemData>(allowInheritance: true);
+```
+
+### Dynamic Values
+
+`L10nContext` can resolve dynamic values from the context object:
+
+```yml
+Game.Item.HealthPotion.desc: "Restores {amount} HP."
+```
+
+If `itemData.amount` exists, `{amount}` can be resolved from `BaseValue`.
+
+You can also override `GetEscapeValue`:
+
+```csharp
+public override object GetEscapeValue(string escapeKey, L10nParams parameters)
+{
+    switch (escapeKey)
+    {
+        case "level":
+            return parameters.GetVariableOrDefault("level", 0);
+
+        case "power":
+            int level = parameters.GetVariableOrDefault("level", 0);
+            return item.GetPower(level);
+
+        default:
+            return base.GetEscapeValue(escapeKey, parameters);
+    }
+}
+```
+
+### Global Dynamic Values
+
+Global values are useful for input labels, platform names, player names, and other shared values:
+
+```csharp
+L10nContext.GlobalEscapeValue["Key_Confirm"] = static (_, _) => "Space";
+```
+
+Language entry:
+
+```yml
+Game.UI.ConfirmHint.info: "Press {Key_Confirm} to continue."
+```
+
+### Local Dynamic Values
+
+A single context can register temporary resolvers:
+
+```csharp
+var context = L10nContext.Of(itemData);
+context.LocalEscapeValue["bonus"] = static (_, _) => "10";
+```
+
+`LocalEscapeValue` stores `DynamicValueProvider` delegates, and the delegate returns `string`.
+
+## Localization String Syntax
+
+Localization entries are resolved through a small pipeline:
+
+1. `$...$` / `$@...$` key references
+2. `{...}` dynamic values and expressions
+3. `§...§` color tags
+4. nested results, until the maximum recursion depth is reached
+
+The maximum recursion depth is controlled by `L10n.MAX_RECURSION`.
+
+### Dynamic Values
+
+```yml
+Game.UI.Player.Level.info: "Level: {level}"
+```
+
+Runtime:
+
+```csharp
+L10n.Tr("Game.UI.Player.Level.info", L10nParams.Create().With("level", 5));
+```
+
+Dynamic values can be resolved from:
+
+- variables passed through `L10nParams.With(...)`
+- values provided by the active context
+- registered global escape-value providers
+
+If a dynamic value cannot be resolved, the output falls back to the variable name or records diagnostics, depending on the translation path.
+
+### Number Formatting
+
+Dynamic values support a format segment after `:`.
+
+```yml
+Game.UI.Timer.info: "Time: {seconds:0.0}s"
+```
+
+The format is applied to the final value:
+
+```yml
+Game.Skill.Duration.info: "Duration: {windup + lifetime:0.0}s"
+```
+
+### Expressions
+
+`{...}` can contain simple expressions:
+
+```yml
+Game.Skill.Cooldown.info: "Cooldown: {cooldown}s"
+Game.Skill.Damage.info: "Damage: {damage:0}"
+Game.Skill.Duration.info: "Total duration: {windup + lifetime:0.0}s"
+```
+
+Expression values can come from `L10nParams`, the active context, or global dynamic-value providers.
+
+### Dynamic Value Parameters
+
+Dynamic values can receive one-off parameters with `<...>`:
+
+```yml
+Game.Skill.Duration.info: "Level 3 duration: {duration<level=3>:0.0}s"
+```
+
+When this is parsed:
+
+- `duration` is the escape key
+- `<level=3>` is converted into `L10nParams`
+- the context can read it with `parameters.GetVariableOrDefault("level", 0)`
+
+Example context:
+
+```csharp
+public sealed class SkillL10nContext : L10nContext
+{
+    private SkillData skill;
+
+    protected override void Parse(object value)
+    {
+        skill = (SkillData)value;
+        BaseKeyString = $"Game.Skill.{skill.ID}";
+        BaseValue = skill;
+    }
+
+    public override object GetEscapeValue(string escapeKey, L10nParams parameters)
+    {
+        int level = parameters.GetVariableOrDefault("level", skill.Level);
+
+        switch (escapeKey)
+        {
+            case "duration":
+                return skill.GetDuration(level);
+
+            case "cooldown":
+                return skill.GetCooldown(level);
+
+            default:
+                return base.GetEscapeValue(escapeKey, parameters);
+        }
+    }
+}
+```
+
+### Key References
+
+Use `$Other.Key$` to embed another localized string:
+
+```yml
+Game.UI.Inventory.Empty.msg: "No $Game.Item.Generic.name$ found."
+Game.Item.Generic.name: "item"
+```
+
+Use `$@Other.Key$` when the reference should be imported with tooltip behavior according to the manager's reference import settings.
+
+Example:
+
+```yml
+docs.movement.name: "Movement Control"
+docs.quickStart.msg: "See $docs.movement.name$ for details."
+docs.tooltip.msg: "See $@docs.movement.name$ for details."
+```
+
+With link and underline import enabled, `$@docs.movement.name$` can produce a result similar to:
+
+```html
+<link=docs.movement.name><u>Movement Control</u></link>
+```
+
+### Color Tags
+
+Use `§` tags for color formatting:
+
+```yml
+Game.UI.Warning.msg: "§RWarning§"
+Game.UI.Rarity.Legendary.name: "§#FFD700Legendary§"
+Game.UI.Element.Fire.name: "§<Fire>Fire§"
+```
+
+Supported color selectors:
+
+- single-letter color codes such as `R`, `G`, `B`
+- hex colors such as `#FFD700`
+- named resolver tags such as `<Fire>`
+
+Color tags are converted to TextMeshPro-compatible `<color=...>` tags.
+
+Single-letter colors:
+
+| Marker | Color |
+| --- | --- |
+| `B` / `b` | `Color.blue` |
+| `G` / `g` | `Color.green` |
+| `R` / `r` | `Color.red` |
+| `C` / `c` | `Color.cyan` |
+| `M` / `m` | `Color.magenta` |
+| `Y` / `y` | `Color.yellow` |
+| `K` / `k` | `Color.black` |
+| `W` / `w` | `Color.white` |
+
+Named colors are resolved through `ColorResolvers.Resolve(name)`. A project can register a custom resolver:
+
+```csharp
+ColorResolvers.Register(ProjectColorPalette.Resolve);
+```
+
+References, variables, and colors can be combined:
+
+```yml
+Game.UI.Help.msg: "§Y$@docs.movement.name$§"
+Game.UI.Power.info: "Power: §R{power:0}§"
+```
+
+### Escaping Syntax Characters
+
+Use a backslash to escape special syntax characters:
+
+```yml
+Game.UI.Example.msg: "Use \{braces\}, \$dollars\$, and \§color markers\§ literally."
+```
+
+### Combined Example
+
+Template:
+
+```yml
+Game.Skill.Projectile.tip: "Projectile lasts {duration<level=1>:0.0}s. See $@docs.projectile.life.name$ - §Yimportant§."
+docs.projectile.life.name: "Projectile Lifetime"
+```
+
+With tooltip import enabled, the output can look like:
+
+```html
+Projectile lasts 2.3s. See <link=docs.projectile.life.name><u>Projectile Lifetime</u></link> - <color=yellow>important</color>.
+```
+
+## UI Components
+
+### TextMeshPro
+
+Attach `TextLocalizer` to a GameObject with `TMP_Text`.
+
+```csharp
+using Minerva.Localizations.Components;
+
+public class Example : MonoBehaviour
+{
+    public TextLocalizer localizer;
+
+    private void Start()
+    {
+        localizer.Load("Game.UI.MainMenu.Start.name");
+    }
+}
+```
+
+`TextLocalizer` requires a `TMP_Text` component and writes the translated result into `textField.text`.
+
+### Legacy Unity UI Text
+
+Use `TextLocalizerLegacyText` for legacy `UnityEngine.UI.Text`.
+
+### Custom Text Localizer
+
+Derive from `TextLocalizerBase` when the target text component is custom:
+
+```csharp
+using Minerva.Localizations.Components;
+
+public sealed class MyTextLocalizer : TextLocalizerBase
+{
+    public MyTextComponent target;
+
+    public override void SetDisplayText(string text)
+    {
+        target.Value = text;
+    }
+}
+```
+
+`TextLocalizerBase.Load()` translates the assigned key with `L10n.Tr(...)` or `L10n.TrKey(...)` when a context is provided.
+
+## Language Files
+
+### Source `.yml`
+
+`.yml` files are useful as source files for key authoring.
+
+```yml
+Game.UI.Common.Confirm.name: Confirm
+Game.UI.Common.Cancel.name: Cancel
+Game.UI.Common.Back.name: Back
+```
+
+### Player-Language `.lang`
+
+`.lang` files hold concrete translations for a region.
+
+```yml
+Game.UI.Common.Confirm.name: Confirm
+Game.UI.Common.Cancel.name: Cancel
+Game.UI.Common.Back.name: Back
+```
+
+The package imports these files into `LanguageFile` assets.
+
+### LanguageFile Assets
+
+`LanguageFile` assets contain:
+
+- `tag`
+- `region`
+- `entries`
+- `isMasterFile`
+- `masterFile`
+- `childFiles`
+- `wordSpace`
+- `listDelimiter`
+
+Master files merge their own entries and child-file entries. If duplicate keys exist, the later imported entry overrides the earlier one and a warning is logged.
+
+## Editor Workflow
+
+### Add a Key
+
+Use `L10nDataManager.AddKey(...)` or `AddKeyToFile(...)` from editor scripts:
+
+```csharp
+manager.AddKeyToFile(
+    "Game.UI.MainMenu.Start.name",
+    fileTag: "UI",
+    defaultValue: "Start"
+);
+```
+
+### Move or Remove a Key
+
+```csharp
+manager.MoveKey(oldKey, newKey);
+manager.RemoveKey(key);
+```
+
+### Sort Entries
+
+```csharp
+manager.SortEntries();
+```
+
+### Export / Import CSV
+
+The manager has context-menu actions for CSV export/import. CSV export creates a table where rows are localization keys and columns are regions.
+
+### Rebuild Key List
+
+The manager can rebuild its key collection from all registered files and sources:
+
+```csharp
+manager.RebuildKeyList();
+```
+
+This is useful after importing external localization files or changing the registered source files.
+
+## Key Naming Guidelines
+
+The package does not require a specific key shape. A practical convention is:
+
+```text
+Game.[Category].[OptionalSubCategory].[Name].[Suffix]
+```
+
+Examples:
+
+```text
+Game.UI.MainMenu.Start.name
+Game.Item.HealthPotion.name
+Game.Item.HealthPotion.desc
+Game.UI.Timer.info
+```
+
+Common suffixes:
+
+| Suffix | Use for |
+| --- | --- |
+| `name` | Display names, labels, button/action names |
+| `desc` | Stable descriptions of objects, actions, options, or effects |
+| `msg` | Player-facing message body text |
+| `title` | Window, panel, or section titles |
+| `hint` | Tutorial hints or interaction hints |
+| `info` | Context-specific labels, values, readouts, status text, or stat blocks |
+| `tip` | Tooltip text |
+
+Use the suffix to describe the kind of text, not the UI flow that displays it. For example, confirmation window body text can use `.msg`:
+
+```text
+Game.UI.MainMenu.Quit.msg
+```
+
+## Missing Keys
+
+The manager controls missing-key behavior through `MissingKeySolution`:
+
+| Value | Behavior |
+| --- | --- |
+| `RawDisplay` | Display the raw key |
+| `Empty` | Display an empty string |
+| `ForceDisplay` | Display a generated value, usually based on the last part of the key |
+| `Fallback` | Fallback to another language |
+
+`L10n.OnKeyMissing` is invoked when a key cannot be resolved.
+
+## Troubleshooting
+
+### Localization Did Not Initialize
+
+Check that this asset exists:
+
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
+```
+
+Then verify that its `manager` field references a valid `L10nDataManager`.
+
+### Key Appears in Editor but Not in Game
+
+Check that:
+
+- the target region is loaded with `L10n.Load(region)`
+- the key exists in the active `LanguageFile`
+- the active `LanguageFile` is registered in `L10nDataManager.files`
+- the file's `region` matches the loaded region string exactly
+
+### TextLocalizer Does Not Update
+
+Check that:
+
+- the component has a non-empty key
+- `L10n` has loaded a region
+- the key exists in the active localization files
+- for `TextLocalizer`, the GameObject also has a `TMP_Text` component
+- the component is enabled
+
+### Dynamic Value Prints the Variable Name
+
+If `{value}` prints as `value`, the variable was not found. Pass it through `L10nParams.With(...)` or provide it from the active context.
+
+### Key Reference Does Not Expand
+
+Check that the referenced key exists and that the `$...$` marker is closed.
+
+### Color Tag Is Not Converted
+
+Check that the tag is closed:
+
+```yml
+Game.UI.Example.msg: "§RRed Text§"
+```
+
+For nested colors, prefer TextMeshPro color tags instead of nesting `§` tags.
+
+## API Reference
+
+| API | Purpose |
+| --- | --- |
+| `L10n.Init()` | Initialize from `LocalizationSettings` |
+| `L10n.Init(manager)` | Initialize from a specific `L10nDataManager` |
+| `L10n.Load(region)` | Load a region |
+| `L10n.InitAndLoad(manager, region)` | Initialize and load in one call |
+| `L10n.Reload()` | Reload current localization |
+| `L10n.Tr(key, params)` | Translate a key |
+| `L10n.Tr(context, params)` | Translate an object/context |
+| `L10n.TrKey(key, context, params)` | Translate with an explicit key and context |
+| `L10n.TrRaw(raw, context, params)` | Resolve a raw localization string |
+| `L10n.TryTr(...)` | Translate and return diagnostics |
+| `L10n.TrDefault(...)` | Translate from the default region |
+| `L10n.Contains(key)` | Check the current localization file |
+| `L10n.Exist(key)` | Check any localization file |
+| `L10n.Write(key, value)` | Runtime override until reload |
+| `L10n.OptionOf(partialKey)` | Find possible key completions |

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,411 +1,926 @@
-# LOM - Localization
+# Localization
 
-《米埃里亚图书馆》的本地化系统
-
-This system is capable of running in other Unity Projects, but it requires the [Unity Utilities](https://github.com/Minerva-Studio/Unity-Utilities) library.
-
-Discord: [Join](https://discord.com/invite/pPbHMcSB7W)
-
----
-
-> 一个轻量、可扩展、可在运行时/编辑器使用的 Unity 本地化系统
-
----
+一个轻量的 Unity 本地化 package，用于运行时翻译、本地化 UI 文本、对象本地化 context、语言文件资产，以及编辑器侧的 localization 管理。
 
 ## 功能特性
 
-- **键值表本地化**：按 key 获取文本，支持模块化、多来源合并, 提供层级键（`a.b.c`）的管理与查询
-- **表达式/变量求值**: 可选的求值能力，便于在运行时进行简单计算与动态插值。
-- **动态变量与上下文**：`L10nContext`、反射读取对象属性/字段、延迟计算值
-- **轻量表达式**：在模板中进行简单逻辑（条件、默认值、链式属性等）
-- **语言回退链**：如 `zh-CN → en`
-- **可拓展**：自定义 `Formatter`、自定义 `L10nContext`、可挂接缺失键处理
+| 功能 | 说明 |
+| --- | --- |
+| 键值表本地化 | 通过 key 获取文本，支持模块化文件、多来源合并，以及 `game.ui.start` 这类层级 key path。 |
+| 运行时翻译 API | `L10n` 统一处理初始化、语言加载、翻译、缺失 key、运行时 override 与默认 region 读取。 |
+| 结构化参数 | `L10nParams` 区分 key option 段和动态变量，用于替代容易混淆的 legacy `params string[]` 写法。 |
+| 动态变量与 context | `L10nContext` / `ILocalizableContext` 为对象绑定 key root，并为占位符提供运行时变量。 |
+| 表达式解析 | 本地化文本支持 `{value}`、`{a + b}`、`{value:0.0}`，以及带参数的动态变量。 |
+| 内联引用 | `$Key.Path$` / `$@Key.Path$` 可以嵌入其他本地化 key，并参与 tooltip import 行为。 |
+| 颜色标记 | `§Rtext§`、`§#ff8800text§`、`§<Keyword>text§` 会转换为 TMP/UGUI 兼容的 `<color>` tag。 |
+| UI 组件 | 内置 localizer 支持 TextMeshPro 与 legacy `UnityEngine.UI.Text`。 |
+| 编辑器工具 | 支持 `.yml` / `.lang` 导入、key 管理、CSV 导入导出、排序、缺失 key 等编辑器工作流。 |
+| 扩展点 | 项目可以提供自定义 formatter、context、颜色 resolver 和缺失 key 行为。 |
 
----
+## 安装要求
 
-## 目录
+- Unity `2021.3` 或更新版本
+- 能够从 `Assets/Resources` 加载资源的 Unity 项目
+- 本 package 需要的 Unity utility 依赖
+- 如果使用 TextMeshPro localizer 组件，需要 TextMeshPro
 
-- [LOM - Localization](#lom---localization)
-  - [功能特性](#功能特性)
-  - [目录](#目录)
-  - [安装 \& 要求](#安装--要求)
-    - [方式 A：通过 UPM（推荐）](#方式-a通过-upm推荐)
-    - [方式 B：以源码/子模块引入](#方式-b以源码子模块引入)
-  - [快速开始](#快速开始)
-  - [核心概念](#核心概念)
-    - [L10nDataManager（数据中枢）](#l10ndatamanager数据中枢)
-    - [L10n（门面 API）](#l10n门面-api)
-    - [LanguageFile（语言文件模型）](#languagefile语言文件模型)
-    - [典型接口（以源码为准）：](#典型接口以源码为准)
-  - [内联标记](#内联标记)
-    - [键引用（Inline Reference）](#键引用inline-reference)
-      - [作用](#作用)
-      - [语法](#语法)
-      - [转义](#转义)
-    - [着色（等价于 `<color>` ）](#着色等价于-color-)
-      - [单字母色表](#单字母色表)
-      - [示例](#示例)
-      - [嵌套与组合](#嵌套与组合)
-      - [转义](#转义-1)
-    - [变量、表达式系统（Expressions）](#变量表达式系统expressions)
-      - [特性](#特性)
-      - [概览](#概览)
-      - [语法与求值规则](#语法与求值规则)
-      - [解析顺序](#解析顺序)
-      - [错误处理](#错误处理)
-      - [示例一览](#示例一览)
-      - [模板语法](#模板语法)
-    - [解析顺序与深度](#解析顺序与深度)
-    - [示例](#示例-1)
+`package.json` 中声明的包信息：
 
----
+```json
+{
+  "name": "com.minervagamestudio.localization",
+  "version": "0.4.0",
+  "displayName": "Localization",
+  "unity": "2021.3"
+}
+```
 
-## 安装 & 要求
+## 安装方式
 
-- **Unity 版本**: Unity 2021.3 LTS
-- **安装方式**：
-  - 作为 Unity 包引入（UPM Git URL / 本地包）
-  - 或将目录整体拷贝到你的工程
+在 `Packages/manifest.json` 中添加：
 
-### 方式 A：通过 UPM（推荐）
+```json
+{
+  "dependencies": {
+    "com.minervagamestudio.localization": "https://github.com/minerva-studio/localization.git"
+  }
+}
+```
 
-1. 打开 **Package Manager**：`Window > Package Manager`
-2. 点击左上角 **+** → **Add package from git URL...**
-3. 粘贴：https://github.com/minerva-studio/localization.git
-4. 按提示完成安装。
+也可以在 Unity 中通过 Package Manager 安装：
 
-### 方式 B：以源码/子模块引入
+```text
+Window > Package Manager > + > Add package from git URL...
+```
 
-- 将本仓库的 `Runtime/`（以及需要的 `Editor/`）拷贝或以 **git submodule** 的方式加入你的工程。
+然后粘贴：
 
-> **兼容性**：建议 Unity 2023.1 或更高版本。
-
----
+```text
+https://github.com/minerva-studio/localization.git
+```
 
 ## 快速开始
 
----
+### 1. 创建 Localization Manager
+
+从 Unity 资产菜单创建 `L10nDataManager`：
+
+```text
+Create > Localization > Localization Manager
+```
+
+Manager 负责管理：
+
+- `defaultRegion`
+- `regions`
+- `files`
+- `sources`
+- `missingKeySolution`
+- `referenceImportOption`
+- `tooltipImportOption`
+- `useUnderlineResolver`
+- `wordSpace`
+- `listDelimiter`
+
+### 2. 把 Manager 赋给 Localization Settings
+
+Package 会从以下路径加载项目设置：
+
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
+```
+
+打开 `LocalizationSetting` asset，把 `L10nDataManager` 赋给它的 `manager` 字段。
+
+运行时，`LocalizationSettings` 会从 `Resources` 加载这个 asset，并初始化 `L10n`。
+
+### 3. 创建语言文件
+
+语言文件可以是 `LanguageFile` asset，也可以由 `.lang` / `.yml` 文件导入。
+
+推荐目录结构：
+
+```text
+Assets/
+  Resources/
+    Localization/
+      LocalizationSetting.asset
+      Base/
+        Lang_UI.yml
+      EN_US/
+        Lang_UI_EN_US.lang
+      ZH_CN/
+        Lang_UI_ZH_CN.lang
+```
+
+Region 字符串需要和 `L10nDataManager.regions` 中配置的值完全一致。
+
+示例 entries：
+
+```yml
+Game.UI.MainMenu.Start.name: Start
+Game.UI.MainMenu.Quit.name: Quit
+Game.UI.MainMenu.Quit.msg: Are you sure you want to quit?
+```
+
+### 4. 加载 region
+
+系统会从 `LocalizationSettings` 自动初始化；游戏也可以显式加载 region：
+
+```csharp
+using Minerva.Localizations;
+
+L10n.Init();
+L10n.Load("EN_US");
+```
+
+也可以使用指定 manager 初始化：
+
+```csharp
+L10n.InitAndLoad(manager, "EN_US");
+```
+
+语言加载后会触发 `L10n.OnLocalizationLoaded`。内置文本 localizer 会监听这个事件并刷新文本。
 
 ## 核心概念
 
-### L10nDataManager（数据中枢）
+### L10nDataManager
 
-- 管理当前语言、回退链、来源注册与合并、缓存与缺失键处理
-- 工作流程：拉取对应语言的 LanguageFile，合并为可查询的键值表，提供给 L10n 查询
+`L10nDataManager` 是 localization 数据的编辑器与运行时中枢。它是一个 `ScriptableObject`，可以从以下菜单创建：
 
-### L10n（门面 API）
-
-- 面向业务层的简洁入口
-- 内部：负责把模板交给 Parser 与 Formatter
-
-### LanguageFile（语言文件模型）
-
-- 建议约定：
-  - key 使用分段命名：menu.file.open、npc.blacksmith.greet
-  - 一文件一语言、可按模块拆分：Lang_UI.lang, Lang_NPC.lang
-
-### 典型接口（以源码为准）：
-
-- L10nContext（上下文/动态变量）
-- 变量作用域：可注入基础类型、对象、字典、委托/函数
-- 支持反射获取对象的公共属性/字段：{player.name}、{item.Price}
-- 支持动态值（懒计算）：WithFunc("now", () => DateTime.Now)
-
----
-
-## 内联标记
-
----
-
-### 键引用（Inline Reference）
-
-#### 作用
-
-把 \$Key.path\$ 替换为当前语言下键 Key.path 的已渲染文本（会再次走同一套渲染流程与回退链）。
-\$@Key.path\$ 是“加强版”引用：在替换为其值的同时，加上链接与下划线样式。可以结合自己实现的内联提示。
-
-行为开关（由 L10nDataManager 控制），参考[ReferenceImportOption.cs](./Runtime/Utilities/ReferenceImportOption.cs)
-
-- \$...\$：默认为 None
-- \$@...\$：默认为 ReferenceImportOption.WithLinkTag | ReferenceImportOption.WithUnderline
-
-#### 语法
-
-- 基本：$key.path$、$@key.path$
-- key.path 为另一条本地化键，按当前语言→回退链查找并渲染。
-- 允许嵌套（见解析顺序与深度限制）。
-
-#### 转义
-
-- 使用反斜杠转义：\\\$ 输出字面 \$
-  例："\$not-a-reference$" → $not-a-reference$
-
-```
-"See $docs.movement$ for details."
-"See $@docs.movement$ for details."       // 带 <link> + 下划线
+```text
+Create > Localization > Localization Manager
 ```
 
-若 docs.movement = "Movement Control"，并且 $@...$ 打开链接与下划线，则输出：
+它负责管理支持的 regions、语言文件、源文件、key collection 重建、排序、导入导出行为、引用导入选项、tooltip 导入选项，以及缺失 key 行为。
 
-```
-"See <u><link=docs.movement>Movement Control</link></u> for details."
-```
+### LocalizationSettings
 
-> `<link>` 的 id 为键名本身
+`LocalizationSettings` 是项目级设置 asset，会从以下路径加载：
 
----
-
-### 着色（等价于 `<color>` ）
-
-§...§ 用于给一段文本着色，等价于 TMP/UGUI 的 \<color=...\> ... \</color\>。
-两种写法：
-
-- 固定色名（单字母）：§Y ... §
-- Hex 颜色：§#rrggbb ... § 或 §#rrggbbaa ... §
-
-#### 单字母色表
-
-下列字母（大小写等价）映射到 Unity Color：
-
-| 标记    | 颜色            |
-| ------- | --------------- |
-| `B`/`b` | `Color.blue`    |
-| `G`/`g` | `Color.green`   |
-| `R`/`r` | `Color.red`     |
-| `C`/`c` | `Color.cyan`    |
-| `M`/`m` | `Color.magenta` |
-| `Y`/`y` | `Color.yellow`  |
-| `K`/`k` | `Color.black`   |
-| `W`/`w` | `Color.white`   |
-
-#### 示例
-
-```
-"§yWarning§: Low HP!"      →  "<color=yellow>Warning</color>: Low HP!"
-"§#ff8800Critical§"        →  "<color=#ff8800>Critical</color>"
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
 ```
 
-> 注意：§...§ 只负责样式，不会改变 $...$ 或 {...} 的求值；因此把它放在引用/表达式外层可让样式作用于最终文本。
+它保存用于运行时初始化 localization 系统的 `L10nDataManager` 引用。
 
-#### 嵌套与组合
+### L10n
 
-- 可以与 $...$ / {...} 混用：
-  §y$@docs.movement$§ → 给“带链接下划线的引用文本”整体着色。
-- 允许多层 §，但请保证成对闭合；解析时按从左到右匹配最近的闭合 §。
+`L10n` 是主要运行时门面。它负责：
 
-#### 转义
+- `Init`
+- `Load`
+- `Reload`
+- `Tr`
+- `TrKey`
+- `TrRaw`
+- `TryTr`
+- `TrDefault`
+- `Contains`
+- `Exist`
+- `Write`
+- `OptionOf`
 
-- 使用 \§ 输出字面 §。
-  例："Use \§Y to start" → Use §Y to start
+Region 加载完成后会触发 `L10n.OnLocalizationLoaded`，让 UI localizer 或其他监听者刷新显示文本。
 
----
+### LanguageFile
 
-### 变量、表达式系统（Expressions）
+`LanguageFile` 是具体语言内容 asset。它包含 `region`、`tag`、localization `entries`，以及可选的 child files。
 
-#### 特性
+Master file 会合并自身 entries 与 child-file entries。若出现重复 key，后导入的 entry 会覆盖前面的 entry，并输出 warning。
 
-- **层级键空间**：使用点号分隔（默认为 `.`），支持前缀存在性检测、子树提取、分段视图、首层键遍历等。
-- **表达式解析**：在本地化文本中嵌入轻量表达式与变量（`+ - * / ^`、括号、变量）。
+## 运行时 API
 
-#### 概览
+### 基础翻译
 
-- 花括号 { ... } 包裹的是可求值表达式，结果将被转成字符串插入到模板中。
-- 表达式内部可以引用变量、做加法运算，并在尾部通过 : 单个 formatter 对整个表达式结果进行格式化。
-- 变量值来源：模板渲染时的 Localization Context， GetEscapeValue 提供。
-- 变量参数：在变量名后用尖括号 <...> 传入键值对参数，这些参数会作为 GetEscapeValue 的 param 传入，供上下文侧决定返回值。
-
-示例:
-
+```csharp
+string text = L10n.Tr("Game.UI.MainMenu.Start.name", L10nParams.Empty);
 ```
-"projectile will alive for {prelaunchTime + lifetime<level=1>:sec}."
+
+不传 `L10nParams` 的 legacy 调用仍然可用：
+
+```csharp
+string text = L10n.Tr("Game.UI.MainMenu.Start.name");
 ```
 
-- prelaunchTime、lifetime<level=1> 都是变量，由 Context 提供数值。
-- + 表示加法（当前实现语义里，我们只对加法做 AST 解析与求值）
-- :sec 是对整个表达式的最终数值做一次格式化（例如转成“秒”的字符串）。
+### 通过 option 拼接 key
 
-#### 语法与求值规则
+`L10nParams` 中的 option 段会追加到 base key 后面。
 
-1) 插值表达式的最小/完整形态
+```csharp
+string name = L10n.Tr("Game.Item.HealthPotion", L10nParams.Create("name"));
+string desc = L10n.Tr("Game.Item.HealthPotion", L10nParams.Create("desc"));
+```
 
-- 最小形态：{varName} —— 单变量替换
-- 带参数的变量：{varName<k=v>}
-- 表达式（加法）：{varA + varB}、{varA + varB<k=v>}
-- 带格式化：{表达式:formatterName}
+这两个调用分别读取：
 
-> 说明：冒号 : 之后只有一个 formatter，作用于整个表达式结果。不要再使用管道语法（|），也不要在花括号外再接 formatter。
+```text
+Game.Item.HealthPotion.name
+Game.Item.HealthPotion.desc
+```
 
-2) 变量与参数传递
+多个 option 会按顺序追加：
 
-- 变量写法：identifier
-- 变量参数：<key=value[,param...]>
-- 这些参数将以原样字符串传入 GetEscapeValue(string escapeKey, params string[] param) 的 param，你可在 Context 内使用自定义解析方法（例如 GetOpt(param)）提取。
+```csharp
+string desc = L10n.Tr(
+    "Game.Effect.Buff",
+    L10nParams.Create("Fire", "desc")
+);
+```
 
-示例 Context：
+它会读取：
 
-```C#
-public class SkillA : Skill
+```text
+Game.Effect.Buff.Fire.desc
+```
+
+### 传入动态变量
+
+```csharp
+string text = L10n.Tr(
+    "Game.UI.Timer.info",
+    L10nParams.Create().With("seconds", 12.5f)
+);
+```
+
+语言 entry：
+
+```yml
+Game.UI.Timer.info: "Time: {seconds:0.0}s"
+```
+
+### 直接翻译对象
+
+如果某个类型已经注册了 localization context，可以直接传对象：
+
+```csharp
+string displayName = L10n.Tr(itemData, L10nParams.Create("name"));
+string description = L10n.Tr(itemData, L10nParams.Create("desc"));
+```
+
+内部流程是：把对象解析成 `L10nContext.Of(object)`，生成 localization key，读取 raw content，然后解析 localization escape patterns。
+
+### 使用指定 context 翻译
+
+当 key 是显式给出的，但动态变量需要来自某个 context 时，可以使用 `TrKey`：
+
+```csharp
+var context = L10nContext.Of(itemData);
+string text = L10n.TrKey("Game.UI.Inventory.Selected.info", context, L10nParams.Empty);
+```
+
+### 翻译 raw content
+
+当 raw string 已经存在，但仍需要解析变量、引用或颜色标记时，使用 `TrRaw`：
+
+```csharp
+var context = L10nContext.Of(itemData);
+
+string text = L10n.TrRaw(
+    "Price: {price}",
+    context,
+    L10nParams.Empty
+);
+```
+
+### 默认 region 翻译
+
+使用 `TrDefault` 从默认 localization region 读取文本：
+
+```csharp
+string fallback = L10n.TrDefault("Game.UI.MainMenu.Start.name", L10nParams.Empty);
+```
+
+## L10nParams
+
+`L10nParams` 用于区分 key option 段和动态变量。
+
+### 空参数
+
+```csharp
+var parameters = L10nParams.Empty;
+var another = L10nParams.Create();
+```
+
+### Option 段
+
+```csharp
+var nameOption = L10nParams.Create("name");
+var nestedOption = L10nParams.Create("Fire", "desc");
+```
+
+### 变量
+
+```csharp
+var parameters = L10nParams
+    .Create("desc")
+    .With("level", 2)
+    .With("damage", 12.5f);
+```
+
+也可以一次添加多个变量：
+
+```csharp
+var parameters = L10nParams
+    .Create("desc")
+    .With(
+        ("level", 2),
+        ("damage", 12.5f),
+        ("cooldown", 3.0f)
+    );
+```
+
+### 修改 option
+
+```csharp
+parameters = parameters.WithOptions("name");
+parameters = parameters.AppendOptions("tooltip");
+parameters = parameters.PrependOptions("Common");
+```
+
+### Legacy string 参数
+
+Legacy string 参数会通过 `L10nParams.FromStrings(...)` 转换。
+
+```csharp
+L10n.Tr("Game.Item.HealthPotion", "name", "level=2");
+```
+
+转换规则：
+
+- 不包含 `=` 的字符串会成为 option
+- 包含 `=` 的字符串会成为变量
+
+例如 `["Daily", "level=2", "desc"]` 会变成：
+
+- Options: `["Daily", "desc"]`
+- Variables: `{ "level": "2" }`
+
+新代码建议显式使用 `L10nParams`：
+
+```csharp
+L10n.Tr(
+    "Game.Item.HealthPotion",
+    L10nParams.Create("name").With("level", 2)
+);
+```
+
+## Localization Contexts
+
+Localization context 用来描述对象如何映射到 localization key，以及如何提供动态变量。
+
+### ILocalizableContext
+
+自定义 context 可以实现 `ILocalizableContext`：
+
+```csharp
+using Minerva.Localizations;
+
+public sealed class ItemL10nContext : ILocalizableContext
 {
-    public float prelaunchTime;
-    public float lifetime;
-}
+    private readonly ItemData item;
 
-public class SkillL10nContext : L10nContext
-{
-    public Skill skill;
-
-    public Skill GetSkill(int level) { /* ... */ }
-
-    public override object GetEscapeValue(string escapeKey, params string[] param)
+    public ItemL10nContext(ItemData item)
     {
-        int level = 0;
-        foreach (var arg in GetOpt(param))
+        this.item = item;
+    }
+
+    public string BaseKeyString => $"Game.Item.{item.ID}";
+
+    public object GetEscapeValue(string escapeKey, L10nParams parameters)
+    {
+        return escapeKey switch
         {
-            if (arg.Item1.SequentialEquals("level"))
-                level = int.Parse(arg.Item2);
-        }
-
-        // 通过参数决定本次变量读取的“版本”（例如 level）
-        var skill = GetSkill(level) ?? this.skill;
-
-        // 将 escapeKey 分发到正确的数据源
-        switch (escapeKey)
-        {
-            case "prelaunchTime": return skill.prelaunchTime;
-            case "lifetime":      return skill.lifetime;
-            // 其它变量...
-        }
-
-        // 兜底：交给基类（反射读取已注册对象的字段/属性）
-        return base.GetEscapeValue(escapeKey, param);
+            "level" => item.Level,
+            "rarity" => item.Rarity,
+            _ => escapeKey
+        };
     }
 }
 ```
 
-要点：
+### L10nContext
 
-- 变量名（如 prelaunchTime、lifetime）就是 escapeKey。
-- 变量参数（如 <level=1>）以 param 传入，不参与表达式求值，只影响 Context 如何取值。
-- 你可以用 switch/表驱动/反射等方式返回变量值。
+对于可复用的对象映射，可以继承 `L10nContext` 并注册：
 
-3) 运算与类型
+```csharp
+using Minerva.Localizations;
 
-- 运算：当前表达式解析器支持加法 + 并构建 AST；左右两侧是变量或数值字面量（数值字面量如 1.5、10）。
-- 类型：会优先按数值类型（float/double/decimal 之一）计算；若出现类型不兼容，按以下顺序尝试：
-  1. 将参与运算的操作数转为 float 进行加法
-  2. 若仍失败，抛解析/求值错误（详见“错误处理”）
+public sealed class ItemL10nContext : L10nContext
+{
+    private ItemData item;
 
-4) 格式化（Formatter）
-
-- 位置：紧跟表达式末尾的 :formatterName
-- 次数：仅一次
-- 输入：格式化器接收整个表达式的最终结果（通常是数值，可以是任何结果）
-- 输出：字符串，用于最终替换
-
-示例：{prelaunchTime + lifetime<level=1>:sec}
-
-- 先计算 prelaunchTime + lifetime(level=1)，得到一个数值（例如 2.2）
-- 再交给 sec formatter，例如输出 "2.2 sec" 或本地化后的 "2.2 秒"
-
-> 如果某个 formatter 需要额外参数（例如 :number(precision=2)），参考自定义formatter的实现。
-
-#### 解析顺序
-
-1. 解析花括号内字符串为 AST：
-   - 提取尾部 :formatter（若有）
-   - 解析加法表达式与变量节点；对每个变量解析其 <k=v[,p]> 参数列表（保留字符串形态）
-2. 变量求值：
-   - 对每个变量节点调用 context.GetEscapeValue(escapeKey, params)
-   - 将返回值强制（或尝试）转换为数值，供运算使用
-3. 表达式计算（数值加法）
-4. 格式化：若存在 :formatter，把结果交给对应格式化器，得到字符串
-5. 替换回模板
-
-#### 错误处理
-
-- 未知变量：GetEscapeValue 返回 null 或抛异常 → 记日志并以占位形式输出（原字符串）。
-- 解析错误（非法字符/不完整表达式）或类型错误（无法转为数值参与加法）：
-
-> 具体策略由 L10nDataManager 或 Parser/Evaluator 层统一控制。
-
-#### 示例一览
-
-```
-# 单变量替换（无格式化）
-"CD time: {cooldown}."
-
-# 变量带参数
-"Life time(Lv.3): {lifetime<level=3>}."
-
-# 表达式（加法）
-"Total time: {prelaunchTime + lifetime}."
-
-# 表达式 + 变量参数 + 格式化
-"projectile will alive for {prelaunchTime + lifetime<level=1>:sec}."
+    protected override void Parse(object value)
+    {
+        item = (ItemData)value;
+        BaseKeyString = $"Game.Item.{item.ID}";
+        BaseValue = item;
+    }
+}
 ```
 
-#### 模板语法
+在初始化阶段注册 context：
 
-|    写法    |       含义       |                 说明                  |
-| :--------: | :--------------: | :-----------------------------------: |
-|   {var}    |    单变量替换    | var 由 Context 的 GetEscapeValue 提供 |
-| {var<k=v>} |     变量参数     |   参数数组会原样传给 GetEscapeValue   |
-|  {a + b}   |    加法表达式    | 先从 Context 取 a、b 并转数值后相加\| |
-| {expr:fmt} | 表达式结果格式化 |         作用于整个表达式结果          |
-
----
-
-### 解析顺序与深度
-
-- 解析顺序：
-
-1. 键引用：$...$ / $@...$
-- 先匹配并展开 $key$（按 L10n.ReferenceImportOption）与 $@key$（强制 WithLinkTag | WithUnderline）。
-- 对被引用内容再做一遍局部管线：$ → {} → §（见第 1.1 步）。
-- 生成 <link=...> 与 <u>...</u> 时：
-  - UseUnderlineResolver == WhileLinking：在这里对下划线与 <color> 分段进行就地拆分。
-- 超过递归深度（L10n.MAX_RECURSION）直接停止并标记为缺失。
-
-2. 动态表达式：{...}
-解析表达式（变量支持行内参数 <k=v>，变量由 context.GetEscapeValue 提供；当前以加法等为主），再应用尾随 :formatter（若有）。
-若表达式结果是字符串，再额外跑一次键引用解析（允许 {...} 结果里出现 $key$）。
-
-3. 着色：§...§
-§Y...§ 等单字母映射到固定颜色；§#RRGGBB(...)...§ 映射为 <color=...>...</color>。
-
-对动态表达式/键引用循环上述步骤
-收尾
-
-1. 反斜杠归一：
- 收尾把 \\ 还原为 \（用于前面阶段的转义书写）。
-
-1. 全局下划线拆分（可选）：
-若 UseUnderlineResolver == Always，在最末尾对整段文本执行一次下划线与 <color> 的分段拆分（保证 <u> 不跨色块）。
-
-
-> 循环与深度限制：循环引用（A → B → A）的最大上限为20，超过该上限后，最后一级的内容将不会被处理
-
-### 示例
-
-模板
-
-```
-"projectile will alive for {prelaunchTime + lifetime<level=1>:sec}. See $@docs.projectile.life$ — §yimportant§."
+```csharp
+L10nContext.Register<ItemL10nContext, ItemData>();
 ```
 
-上下文（摘录）
+如果同一个 context 也要应用到子类：
 
-```
-// 表达式变量：来自 SkillL10nContext
-prelaunchTime = 0.3f;
-lifetime= 2.0f; // when level=1
-
-// 引用键
-docs.projectile.life = "Projectile Lifetime";
+```csharp
+L10nContext.Register<ItemL10nContext, ItemData>(allowInheritance: true);
 ```
 
-渲染结果（示例，使用 TMP 标签）
+### 动态变量
 
+`L10nContext` 可以从 context 对象解析动态变量：
+
+```yml
+Game.Item.HealthPotion.desc: "Restores {amount} HP."
 ```
-"projectile will alive for 2.3 sec. See <u><link=docs.projectile.life>Projectile Lifetime</link></u> — <color=yellow>important</color>."
+
+如果 `itemData.amount` 存在，`{amount}` 可以从 `BaseValue` 解析。
+
+也可以重写 `GetEscapeValue`：
+
+```csharp
+public override object GetEscapeValue(string escapeKey, L10nParams parameters)
+{
+    switch (escapeKey)
+    {
+        case "level":
+            return parameters.GetVariableOrDefault("level", 0);
+
+        case "power":
+            int level = parameters.GetVariableOrDefault("level", 0);
+            return item.GetPower(level);
+
+        default:
+            return base.GetEscapeValue(escapeKey, parameters);
+    }
+}
 ```
+
+### 全局动态变量
+
+全局变量适合输入按键、平台名、玩家名等共享值：
+
+```csharp
+L10nContext.GlobalEscapeValue["Key_Confirm"] = static (_, _) => "Space";
+```
+
+语言 entry：
+
+```yml
+Game.UI.ConfirmHint.info: "Press {Key_Confirm} to continue."
+```
+
+### 局部动态变量
+
+单个 context 可以注册临时 resolver：
+
+```csharp
+var context = L10nContext.Of(itemData);
+context.LocalEscapeValue["bonus"] = static (_, _) => "10";
+```
+
+`LocalEscapeValue` 存储的是 `DynamicValueProvider` delegate，这个 delegate 返回 `string`。
+
+## Localization String Syntax
+
+Localization entry 会按一个轻量管线解析：
+
+1. `$...$` / `$@...$` key 引用
+2. `{...}` 动态变量与表达式
+3. `§...§` 颜色标记
+4. 嵌套结果，直到达到最大递归深度
+
+最大递归深度由 `L10n.MAX_RECURSION` 控制。
+
+### 动态变量
+
+```yml
+Game.UI.Player.Level.info: "Level: {level}"
+```
+
+运行时：
+
+```csharp
+L10n.Tr("Game.UI.Player.Level.info", L10nParams.Create().With("level", 5));
+```
+
+动态变量可以来自：
+
+- 通过 `L10nParams.With(...)` 传入的变量
+- 当前 context 提供的值
+- 已注册的全局 escape-value provider
+
+如果动态变量无法解析，输出会回退为变量名本身，或根据翻译路径记录诊断信息。
+
+### 数字格式化
+
+动态变量支持在 `:` 后添加格式：
+
+```yml
+Game.UI.Timer.info: "Time: {seconds:0.0}s"
+```
+
+格式会作用于最终值：
+
+```yml
+Game.Skill.Duration.info: "Duration: {windup + lifetime:0.0}s"
+```
+
+### 表达式
+
+`{...}` 中可以写简单表达式：
+
+```yml
+Game.Skill.Cooldown.info: "Cooldown: {cooldown}s"
+Game.Skill.Damage.info: "Damage: {damage:0}"
+Game.Skill.Duration.info: "Total duration: {windup + lifetime:0.0}s"
+```
+
+表达式里的值可以来自 `L10nParams`、当前 context，或全局 dynamic-value provider。
+
+### 动态变量参数
+
+动态变量可以通过 `<...>` 接收一次性参数：
+
+```yml
+Game.Skill.Duration.info: "Level 3 duration: {duration<level=3>:0.0}s"
+```
+
+解析时：
+
+- `duration` 是 escape key
+- `<level=3>` 会被转换成 `L10nParams`
+- context 可以通过 `parameters.GetVariableOrDefault("level", 0)` 读取它
+
+示例 context：
+
+```csharp
+public sealed class SkillL10nContext : L10nContext
+{
+    private SkillData skill;
+
+    protected override void Parse(object value)
+    {
+        skill = (SkillData)value;
+        BaseKeyString = $"Game.Skill.{skill.ID}";
+        BaseValue = skill;
+    }
+
+    public override object GetEscapeValue(string escapeKey, L10nParams parameters)
+    {
+        int level = parameters.GetVariableOrDefault("level", skill.Level);
+
+        switch (escapeKey)
+        {
+            case "duration":
+                return skill.GetDuration(level);
+
+            case "cooldown":
+                return skill.GetCooldown(level);
+
+            default:
+                return base.GetEscapeValue(escapeKey, parameters);
+        }
+    }
+}
+```
+
+### Key 引用
+
+使用 `$Other.Key$` 嵌入另一个 localization key 的翻译结果：
+
+```yml
+Game.UI.Inventory.Empty.msg: "No $Game.Item.Generic.name$ found."
+Game.Item.Generic.name: "item"
+```
+
+当引用结果需要根据 manager 的引用导入设置生成 tooltip 行为时，可以使用 `$@Other.Key$`。
+
+示例：
+
+```yml
+docs.movement.name: "Movement Control"
+docs.quickStart.msg: "See $docs.movement.name$ for details."
+docs.tooltip.msg: "See $@docs.movement.name$ for details."
+```
+
+在启用 link 和 underline 导入时，`$@docs.movement.name$` 可以产生类似结果：
+
+```html
+<link=docs.movement.name><u>Movement Control</u></link>
+```
+
+### 颜色标记
+
+使用 `§` 标记颜色：
+
+```yml
+Game.UI.Warning.msg: "§RWarning§"
+Game.UI.Rarity.Legendary.name: "§#FFD700Legendary§"
+Game.UI.Element.Fire.name: "§<Fire>Fire§"
+```
+
+支持的颜色 selector：
+
+- `R`、`G`、`B` 这类单字母颜色代码
+- `#FFD700` 这类 hex 颜色
+- `<Fire>` 这类命名 resolver tag
+
+颜色标记会被转换成 TextMeshPro 兼容的 `<color=...>` tag。
+
+单字母色表：
+
+| 标记 | 颜色 |
+| --- | --- |
+| `B` / `b` | `Color.blue` |
+| `G` / `g` | `Color.green` |
+| `R` / `r` | `Color.red` |
+| `C` / `c` | `Color.cyan` |
+| `M` / `m` | `Color.magenta` |
+| `Y` / `y` | `Color.yellow` |
+| `K` / `k` | `Color.black` |
+| `W` / `w` | `Color.white` |
+
+命名颜色会通过 `ColorResolvers.Resolve(name)` 解析。项目可以注册自己的 resolver：
+
+```csharp
+ColorResolvers.Register(ProjectColorPalette.Resolve);
+```
+
+引用、变量和颜色可以组合：
+
+```yml
+Game.UI.Help.msg: "§Y$@docs.movement.name$§"
+Game.UI.Power.info: "Power: §R{power:0}§"
+```
+
+### 转义特殊字符
+
+使用反斜杠转义特殊语法字符：
+
+```yml
+Game.UI.Example.msg: "Use \{braces\}, \$dollars\$, and \§color markers\§ literally."
+```
+
+### 组合示例
+
+模板：
+
+```yml
+Game.Skill.Projectile.tip: "Projectile lasts {duration<level=1>:0.0}s. See $@docs.projectile.life.name$ - §Yimportant§."
+docs.projectile.life.name: "Projectile Lifetime"
+```
+
+在启用 tooltip import 时，输出可以类似：
+
+```html
+Projectile lasts 2.3s. See <link=docs.projectile.life.name><u>Projectile Lifetime</u></link> - <color=yellow>important</color>.
+```
+
+## UI Components
+
+### TextMeshPro
+
+把 `TextLocalizer` 挂到带有 `TMP_Text` 的 GameObject 上。
+
+```csharp
+using Minerva.Localizations.Components;
+
+public class Example : MonoBehaviour
+{
+    public TextLocalizer localizer;
+
+    private void Start()
+    {
+        localizer.Load("Game.UI.MainMenu.Start.name");
+    }
+}
+```
+
+`TextLocalizer` 需要 `TMP_Text` 组件，并会把翻译结果写入 `textField.text`。
+
+### Legacy Unity UI Text
+
+Legacy `UnityEngine.UI.Text` 使用 `TextLocalizerLegacyText`。
+
+### 自定义文本 localizer
+
+当目标文本组件是自定义类型时，可以继承 `TextLocalizerBase`：
+
+```csharp
+using Minerva.Localizations.Components;
+
+public sealed class MyTextLocalizer : TextLocalizerBase
+{
+    public MyTextComponent target;
+
+    public override void SetDisplayText(string text)
+    {
+        target.Value = text;
+    }
+}
+```
+
+`TextLocalizerBase.Load()` 会使用 `L10n.Tr(...)` 翻译已配置的 key；如果提供了 context，则使用 `L10n.TrKey(...)`。
+
+## 语言文件
+
+### Source `.yml`
+
+`.yml` 适合作为 key 编写阶段的源文件。
+
+```yml
+Game.UI.Common.Confirm.name: Confirm
+Game.UI.Common.Cancel.name: Cancel
+Game.UI.Common.Back.name: Back
+```
+
+### Player-language `.lang`
+
+`.lang` 文件保存某个 region 的具体翻译。
+
+```yml
+Game.UI.Common.Confirm.name: Confirm
+Game.UI.Common.Cancel.name: Cancel
+Game.UI.Common.Back.name: Back
+```
+
+Package 会把这些文件导入为 `LanguageFile` assets。
+
+### LanguageFile assets
+
+`LanguageFile` asset 包含：
+
+- `tag`
+- `region`
+- `entries`
+- `isMasterFile`
+- `masterFile`
+- `childFiles`
+- `wordSpace`
+- `listDelimiter`
+
+Master file 会合并自身 entries 与 child files 的 entries。若出现重复 key，后导入的 entry 会覆盖前面的 entry，并输出 warning。
+
+## 编辑器工作流
+
+### 添加 key
+
+在编辑器脚本中可以使用 `L10nDataManager.AddKey(...)` 或 `AddKeyToFile(...)`：
+
+```csharp
+manager.AddKeyToFile(
+    "Game.UI.MainMenu.Start.name",
+    fileTag: "UI",
+    defaultValue: "Start"
+);
+```
+
+### 移动或删除 key
+
+```csharp
+manager.MoveKey(oldKey, newKey);
+manager.RemoveKey(key);
+```
+
+### 排序 entries
+
+```csharp
+manager.SortEntries();
+```
+
+### CSV 导入 / 导出
+
+Manager 提供 CSV 导入导出的 context-menu 操作。导出的 CSV 会以 localization key 为行、region 为列。
+
+### 重建 key 列表
+
+Manager 可以从所有已注册的 files 与 sources 重建 key collection：
+
+```csharp
+manager.RebuildKeyList();
+```
+
+这适合在导入外部 localization 文件或修改注册源文件后使用。
+
+## Key 命名建议
+
+Package 不要求固定 key 结构。一个实用约定是：
+
+```text
+Game.[Category].[OptionalSubCategory].[Name].[Suffix]
+```
+
+示例：
+
+```text
+Game.UI.MainMenu.Start.name
+Game.Item.HealthPotion.name
+Game.Item.HealthPotion.desc
+Game.UI.Timer.info
+```
+
+常见 suffix：
+
+| Suffix | 用途 |
+| --- | --- |
+| `name` | 显示名、标签、按钮名、动作名 |
+| `desc` | 对对象、动作、选项、效果的稳定描述 |
+| `msg` | 面向玩家的正文消息 |
+| `title` | 窗口、面板、章节标题 |
+| `hint` | 教程提示或交互提示 |
+| `info` | 当前状态、数值、读数、状态文本、统计块 |
+| `tip` | Tooltip 文本 |
+
+Suffix 应描述文本类型，而不是显示它的 UI 流程。例如确认窗口正文可以使用 `.msg`：
+
+```text
+Game.UI.MainMenu.Quit.msg
+```
+
+## 缺失键处理
+
+Manager 通过 `MissingKeySolution` 控制缺失 key 行为：
+
+| Value | Behavior |
+| --- | --- |
+| `RawDisplay` | 显示 raw key |
+| `Empty` | 显示空字符串 |
+| `ForceDisplay` | 显示生成值，通常基于 key 的最后一段 |
+| `Fallback` | 回退到另一个语言 |
+
+当 key 无法解析时会触发 `L10n.OnKeyMissing`。
+
+## 排查问题
+
+### Localization 没有初始化
+
+检查这个 asset 是否存在：
+
+```text
+Assets/Resources/Localization/LocalizationSetting.asset
+```
+
+然后确认它的 `manager` 字段引用了有效的 `L10nDataManager`。
+
+### 编辑器里有 key，但游戏里没有文本
+
+检查：
+
+- 目标 region 是否已经通过 `L10n.Load(region)` 加载
+- key 是否存在于当前 `LanguageFile`
+- 当前 `LanguageFile` 是否注册在 `L10nDataManager.files`
+- 文件的 `region` 是否和加载的 region 字符串完全一致
+
+### TextLocalizer 没有刷新
+
+检查：
+
+- 组件是否有非空 key
+- `L10n` 是否已经加载 region
+- key 是否存在于当前 localization 文件
+- 对于 `TextLocalizer`，GameObject 是否也有 `TMP_Text` 组件
+- 组件是否 enabled
+
+### 动态变量输出成变量名
+
+如果 `{value}` 输出为 `value`，说明变量没有找到。通过 `L10nParams.With(...)` 传入它，或从当前 context 提供它。
+
+### Key 引用没有展开
+
+检查被引用的 key 是否存在，以及 `$...$` 标记是否闭合。
+
+### 颜色标记没有转换
+
+检查颜色标记是否闭合：
+
+```yml
+Game.UI.Example.msg: "§RRed Text§"
+```
+
+对于嵌套颜色，优先使用 TextMeshPro 原生 color tag，而不是嵌套 `§` 标记。
+
+## API 速查
+
+| API | 用途 |
+| --- | --- |
+| `L10n.Init()` | 从 `LocalizationSettings` 初始化 |
+| `L10n.Init(manager)` | 使用指定 `L10nDataManager` 初始化 |
+| `L10n.Load(region)` | 加载 region |
+| `L10n.InitAndLoad(manager, region)` | 初始化并加载 region |
+| `L10n.Reload()` | 重新加载当前 localization |
+| `L10n.Tr(key, params)` | 翻译 key |
+| `L10n.Tr(context, params)` | 翻译对象或 context |
+| `L10n.TrKey(key, context, params)` | 使用显式 key 和 context 翻译 |
+| `L10n.TrRaw(raw, context, params)` | 解析 raw localization string |
+| `L10n.TryTr(...)` | 翻译并返回诊断信息 |
+| `L10n.TrDefault(...)` | 从默认 region 翻译 |
+| `L10n.Contains(key)` | 检查当前 localization file |
+| `L10n.Exist(key)` | 检查任意 localization file |
+| `L10n.Write(key, value)` | 写入运行时 override，直到 reload |
+| `L10n.OptionOf(partialKey)` | 查找可能的 key 补全 |


### PR DESCRIPTION
## Summary

Updates `README_ZH.md` with a complete Chinese documentation refresh for the localization package.

## Changes

- Fills in the previously empty Quick Start section
- Aligns Unity version wording with `package.json` (`2021.3`)
- Updates examples to prefer the current `L10nParams` API
- Keeps legacy `params string[]` as compatibility guidance only
- Adds runtime API, `L10nParams`, `L10nContext`, UI component, language file, importer, and troubleshooting sections
- Adds a Library of Meialia reference integration section covering `L10nRegistry`, context registration, key roots, tooltip behavior, and Data Editor usage

Related: minerva-studio/library-of-meialia#321